### PR TITLE
Add screen tracker middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,5 @@ import { createNavigationReducer } from './reducer';
 
 export * from './types';
 export * from './middleware';
+export * from "./screen-tracker";
 export { createNavigationReducer };

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -6,6 +6,7 @@ import type {
   NavigationState,
 } from 'react-navigation';
 import type { Middleware } from 'redux';
+import type { NavStateSelector } from './types';
 
 import invariant from 'invariant';
 
@@ -15,7 +16,7 @@ const reduxSubscribers = new Map();
 
 function createReactNavigationReduxMiddleware<State: {}>(
   key: string,
-  navStateSelector: (state: State) => NavigationState,
+  navStateSelector: NavStateSelector<State>,
 ): Middleware<State, *, *> {
   reduxSubscribers.set(key, new Set());
   return store => next => action => {

--- a/src/screen-tracker.js
+++ b/src/screen-tracker.js
@@ -1,0 +1,50 @@
+// @flow
+
+import type { Middleware } from 'redux';
+
+import type {
+  ReducerState,
+  NavStateSelector,
+  OnScreenChangeCallback,
+} from './types';
+
+import { NavigationActions } from "react-navigation";
+
+function getCurrentRouteName(navigationState: ReducerState) {
+  if (!navigationState) return null;
+
+  const route = navigationState.routes[navigationState.index];
+
+  // dive into nested navigators
+  if (route.routes) return getCurrentRouteName(route);
+
+  return route.routeName;
+};
+
+export function createScreenTrackingMiddleware<State: {}> (
+  navStateSelector: NavStateSelector<State>,
+  onScreenChange: OnScreenChangeCallback
+): Middleware<State, *, *> {
+  return store => next => action => {
+    if (
+      action.type !== NavigationActions.NAVIGATE &&
+      action.type !== NavigationActions.BACK
+    ) {
+      return next(action);
+    }
+
+    const oldState = store.getState();
+    const fromScreen = getCurrentRouteName(navStateSelector(oldState));
+
+    const result = next(action);
+
+    const newState = store.getState();
+    const toScreen = getCurrentRouteName(navStateSelector(newState));
+
+    if (toScreen !== fromScreen) {
+      onScreenChange(fromScreen, toScreen);
+    }
+
+    return result;
+  };
+};

--- a/src/types.js
+++ b/src/types.js
@@ -4,3 +4,5 @@ import type { NavigationContainer, NavigationState } from 'react-navigation';
 
 export type Navigator = NavigationContainer<*, *, *>;
 export type ReducerState = ?NavigationState;
+export type NavStateSelector<State> = (state: State) => NavigationState;
+export type OnScreenChangeCallback = (?string, ?string) => any;


### PR DESCRIPTION
```es6
import { GoogleAnalyticsTracker } from "react-native-google-analytics-bridge";
import { createScreenTrackingMiddleware } from "react-navigation-redux-helpers";

const  navStateSelector = (state) => state.navigation

const ScreenTrackingMiddleware = createScreenTrackingMiddleware(
  navStateSelector,
  (fromScreen, toScreen) => {
    tracker.trackScreenView(toScreen);
  }
);
```