### PR TITLE
Added TypeScript definitions file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+declare module 'react-navigation-redux-helpers' {
+    import { NavigationContainer, NavigationEventCallback, NavigationEventSubscription, NavigationState } from 'react-navigation';
+    import { Middleware, Reducer } from 'redux';
+
+    export type Navigator = NavigationContainer<any, any, any>;
+
+    export type ReducerState = NavigationState | null | undefined;
+
+    export function initializeListeners(key: string, state: NavigationState): void;
+
+    export function createReactNavigationReduxMiddleware<S>
+    (key: string, navStateSelector: (state: S) => NavigationState): Middleware;
+
+    export function createReduxBoundAddListener
+    (key: string): (eventName: string, callback: NavigationEventCallback) => NavigationEventSubscription;
+
+    export function createNavigationReducer(navigator: Navigator): Reducer<any, any>;
+}


### PR DESCRIPTION
Here are some issues to be discussed:

1) File `src/types.js` exports `Navigator` type:
```javascript
// @flow

import type { NavigationContainer } from 'react-navigation';

export type Navigator = NavigationContainer<*, *, *>;
```

I tried to just give it a TS-style, but found that `NavigationContainer` of `react-navigation` **is not generic** (see https://github.com/DefinitelyTyped/DefinitelyTyped/blob/9bb6dc2f8bc00c10f8ce8af74916051c84565ffc/types/react-navigation/index.d.ts#L559-L566)

So I'm not sure that this line is correct:
```typescript
export type Navigator = NavigationContainer<any, any, any>;
```

2) A similar problem with the file `src/reducer.js` that exports function `createNavigationReducer`:
```javascript
// @flow

import type { Reducer } from 'redux';
import type { Navigator } from './types'

function createNavigationReducer(navigator: Navigator): Reducer<*, *> {
    // ...
}
```

The problem is that **the latest release of `redux`** has definition of `Reducer` that contains **only one generic argument** (see https://github.com/reactjs/redux/blob/8f60ba321e8ba5fa71d60fa35573c2cdf9c0d852/index.d.ts#L57)
(`beta` pre-releases has two generic arguments, but **pre-release is not a release**)

So I'm not sure that this line is correct:
```typescript
export function createNavigationReducer(navigator: Navigator): Reducer<any, any>;
```