### PR TITLE
Fix reducer

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -14,7 +14,7 @@ function createNavigationReducer(navigator: Navigator): Reducer<*, *> {
     state: ReducerState = initialState,
     action: NavigationAction,
   ): ReducerState => {
-    return navigator.router.getStateForAction(action, state);
+    return navigator.router.getStateForAction(action, state) || state;
   };
 };
 


### PR DESCRIPTION
`.router.getStateForAction` of any navigator can return falsey values (at least `null`). In that case previous state should be returned, as in [v1 Redux integration docs](https://github.com/react-navigation/react-navigation.github.io/blob/1.x/docs/redux-integration.md#step-by-step-guide):

```
const navReducer = (state = initialState, action) => {
  const nextState = AppNavigator.router.getStateForAction(action, state);

  // Simply return the original `state` if `nextState` is null or undefined.
  return nextState || state;
};
```

I'm referring to this part:
```
  // Simply return the original `state` if `nextState` is null or undefined.
  return nextState || state;
```