### PR TITLE
v2 beta to support react-navigation 2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ function createNavigationPropConstructor(
 ): (
   dispatch: NavigationDispatch,
   state: NavigationState,
+  router: NavigationRouter,
+  getCurrentNavigation: () => NavigationScreenProp<NavigationState>,
 ) => NavigationScreenProp<NavigationState>;
 ```
 
@@ -59,6 +61,8 @@ function createNavigationPropConstructor(
 * Prop constructor is called in your main component's `render`.
 * Param `dispatch` is your Redux store's dispatch function.
 * Param `state` is the navigation state for your app.
+* Must provide the `router` from App Navigator
+* Must provide a callback for the navigation prop to access the current navigation prop
 
 ### `createReduxBoundAddListener` (alternative to `createNavigationPropConstructor`)
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ function createNavigationPropConstructor(
 * Prop constructor is called in your main component's `render`.
 * Param `dispatch` is your Redux store's dispatch function.
 * Param `state` is the navigation state for your app.
-* Must provide the `router` from App Navigator
-* Must provide a callback for the navigation prop to access the current navigation prop
+* Param `router` can be obtained from your root navigator: `rootNavigator.router`.
+* Param `getCurrentNavigation` returns the current version of this prop. The parent is expected to maintain a copy of the result of the prop constructor call.
 
 ### `createReduxBoundAddListener` (alternative to `createNavigationPropConstructor`)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-navigation-redux-helpers",
   "description": "Redux middleware and utils for React Navigation",
-  "version": "1.1.2",
+  "version": "2.0.0-beta.0",
   "main": "src/index.js",
   "author": "Ashoat Tevosyan (https://github.com/ashoat)",
   "license": "BSD-2-Clause",

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -17,6 +17,10 @@ import { initAction } from './reducer';
 
 const reduxSubscribers = new Map();
 
+// screenProps are a legacy concept in react navigation, and should not be used in redux apps
+const EMPTY_SCREEN_PROPS = {};
+const getScreenProps = () => EMPTY_SCREEN_PROPS;
+
 function createReactNavigationReduxMiddleware<State: {}>(
   key: string,
   navStateSelector: (state: State) => NavigationState,
@@ -123,16 +127,11 @@ function createNavigationPropConstructor(key: string) {
     dispatch: NavigationDispatch,
     state: NavigationState,
     router: NavigationRouter,
-    getScreenProps,
-    getCurrentNavigation,
+    getCurrentNavigation: () => NavigationScreenProp<NavigationState>,
   ): NavigationScreenProp<NavigationState> => {
     invariant(
       router,
       `App.router must be provided to createNavigationPropConstructor, as of react-navigation-redux-helpers v2. Learn more: https://reactnavigation.org/docs/en/redux-integration.html#breaking-changes-in-2.3`,
-    );
-    invariant(
-      getScreenProps,
-      `getScreenProps must be provided to createNavigationPropConstructor, as of react-navigation-redux-helpers v2. Learn more: https://reactnavigation.org/docs/en/redux-integration.html#breaking-changes-in-2.3`,
     );
     invariant(
       getCurrentNavigation,

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -17,7 +17,8 @@ import { initAction } from './reducer';
 
 const reduxSubscribers = new Map();
 
-// screenProps are a legacy concept in react navigation, and should not be used in redux apps
+// screenProps are a legacy concept in React Navigation,
+// and should not be used in redux apps
 const EMPTY_SCREEN_PROPS = {};
 const getScreenProps = () => EMPTY_SCREEN_PROPS;
 
@@ -32,12 +33,16 @@ function createReactNavigationReduxMiddleware<State: {}>(
     const newState = store.getState();
     const subscribers = reduxSubscribers.get(key);
     invariant(subscribers, `subscribers set should exist for ${key}`);
-    triggerAllSubscribers(key, subscribers, {
-      type: 'action',
-      action,
-      state: navStateSelector(newState),
-      lastState: navStateSelector(oldState),
-    });
+    triggerAllSubscribers(
+      key,
+      subscribers,
+      {
+        type: 'action',
+        action,
+        state: navStateSelector(newState),
+        lastState: navStateSelector(oldState),
+      },
+    );
     return result;
   };
 }
@@ -83,8 +88,8 @@ function createReduxBoundAddListener(key: string) {
   invariant(
     reduxSubscribers.has(key),
     "Cannot listen for a key that isn't associated with a Redux store. " +
-      'First call `createReactNavigationReduxMiddleware` so that we know ' +
-      'when to trigger your listener.',
+      "First call `createReactNavigationReduxMiddleware` so that we know " +
+      "when to trigger your listener.",
   );
   return (eventName: string, handler: NavigationEventCallback) => {
     if (eventName !== 'action') {
@@ -106,15 +111,19 @@ function initializeListeners(key: string, state: NavigationState) {
   invariant(
     subscribers,
     "Cannot initialize listeners for a key that isn't associated with a " +
-      'Redux store. First call `createReactNavigationReduxMiddleware` so ' +
-      'that we know when to trigger your listener.',
+      "Redux store. First call `createReactNavigationReduxMiddleware` so " +
+      "that we know when to trigger your listener.",
   );
-  triggerAllSubscribers(key, subscribers, {
-    type: 'action',
-    action: initAction,
-    state: state,
-    lastState: null,
-  });
+  triggerAllSubscribers(
+    key,
+    subscribers,
+    {
+      type: 'action',
+      action: initAction,
+      state: state,
+      lastState: null,
+    },
+  );
   if (delaySubscriberTriggerUntilReactReduxConnectTriggers) {
     triggerDelayedSubscribers(key);
   }


### PR DESCRIPTION
react-navigation had a breaking change for redux users in v2.3.

Fortunately, this change makes the redux implementation more simple and robust.

Unfortunately, it will require a change for redux users. There are additional required arguments for createNavigationPropConstructor