### PR TITLE
Remove props except a navigation.

### DIFF
--- a/src/reduxify-navigator.js
+++ b/src/reduxify-navigator.js
@@ -52,7 +52,7 @@ function reduxifyNavigator<State: NavigationState, Props: RequiredProps<State>>(
     }
 
     render() {
-      const { dispatch, state, ...props } = this.props;
+      const { dispatch, state } = this.props;
       this.currentNavProp = propConstructor(
         dispatch,
         state,
@@ -61,7 +61,6 @@ function reduxifyNavigator<State: NavigationState, Props: RequiredProps<State>>(
       );
       return (
         <Navigator
-          {...props}
           navigation={this.currentNavProp}
         />
       );


### PR DESCRIPTION
I fixed a bug.

#### What's Issued

<img width="1198" alt="screen shot 2018-06-23 at 9 07 06" src="https://user-images.githubusercontent.com/12597904/41803612-a1f6b0b8-76c5-11e8-8739-ad4f5c4742ff.png">

#### Code Is

```
import { reduxifyNavigator } from 'react-navigation-redux-helpers';
import React, { Component } from 'react';
import { connect } from 'react-redux';
import { createBottomTabNavigator } from 'react-navigation';
import AccountCircle from 'react-icons/lib/md/account-circle';
import Collection from 'react-icons/lib/md/collections-bookmark';


const TabNav = createBottomTabNavigator({
  Home: {
    screen: Home,
    navigationOptions: {
      tabBarLabel: 'Home',
      tabBarIcon: ({ tintColor }) => (<Collection size={35} color={tintColor} />),
    },
  },
  MyPage: {
    screen: MyPage,
    navigationOptions: {
      tabBarLabel: 'MyPage',
      tabBarIcon: ({ tintColor }) => (<AccountCircle size={35} color={tintColor} />),
    },
  },
}, {
  initialRouteName: 'Home',
  tabBarPosition: 'bottom',
});

const ConnectedTabNav = connect(state => ({state: state.routes}))(reduxifyNavigator(TabNav, 'root'));

class App extends Component {
  render() {
    return (
      <View style={ styles.mainContainler }>
          <ConnectedTabNav style={ styles.tabs }/>
      </View>
    );
  }
}
```

#### Environments

```
react@16.3.1
react-redux@5.0.7
redux@4.0.0
react-native-web@0.4.0
react-native@0.55.4
react-navigation@2.5.0
react-navigation-redux-helpers@2.0.2
```