### PR TITLE
add setNavigatorRef callback to reduxifyNavigator()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ function createReactNavigationReduxMiddleware<State: {}>(
 function reduxifyNavigator(
   navigator: Navigator,
   key: string,
+  setNavigatorRef: (navigatorRef) => void
 ): React.ComponentType<{ state: NavigationState, dispatch: Dispatch }>;
 ```
 
@@ -46,6 +47,7 @@ function reduxifyNavigator(
 * `createReactNavigationReduxMiddleware` must be called before this one!
 * Param `navigator` is your root navigator (React component).
 * Param `key` needs to be consistent with the call to `createReactNavigationReduxMiddleware` above.
+* Param `setNavigatorRef` is a callback, where you can set `navigation` to a service to [navigate without navigation prop](https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html).
 * Returns a component to use in place of your root navigator. Pass it `state` and `dispatch` props that you get via `react-redux`'s `connect`.
 
 ### `createNavigationReducer` (optional)

--- a/src/reduxify-navigator.js
+++ b/src/reduxify-navigator.js
@@ -30,6 +30,7 @@ function reduxifyNavigator<State: NavigationState, Props: RequiredProps<State>>(
     $Diff<Props, RequiredProps<State>>,
   >,
   key: string,
+  setNavigatorRef: (navigatorRef) => void
 ): React.ComponentType<Props> {
   const didUpdateCallback = createDidUpdateCallback(key);
   const propConstructor = createNavigationPropConstructor(key);
@@ -63,6 +64,7 @@ function reduxifyNavigator<State: NavigationState, Props: RequiredProps<State>>(
         <Navigator
           {...props}
           navigation={this.currentNavProp}
+          ref={setNavigatorRef}
         />
       );
     }


### PR DESCRIPTION
This PR add `setNavigatorRef` callback as a third parameter of `reduxifyNavigator()`, so that it is possible to set `navigation` to a service to [navigate without navigation prop](https://reactnavigation.org/docs/en/navigating-without-navigation-prop.html)

```
const App = reduxifyNavigator(AppNavigator, "root", navigatorRef => {
  NavigationService.setTopLevelNavigator(navigatorRef);
});
```

This is useful for application, which has heavy redux integration, to migrate to newer `react-navigation` versions.