### PR TITLE
fix:didFocus event can't be triggered due to component update and red…

### DIFF
--- a/src/reduxify-navigator.js
+++ b/src/reduxify-navigator.js
@@ -43,7 +43,9 @@ function reduxifyNavigator<State: NavigationState, Props: RequiredProps<State>>(
     }
 
     componentDidUpdate() {
-      didUpdateCallback();
+      setTimeout(() => {
+        didUpdateCallback();
+      }, 0);
     }
 
     getCurrentNavigation = () => {


### PR DESCRIPTION
…ux middleware execution timing[#53]

I found that `didUpdateCallback`(in ReduxifyNavigator - componentDidUpdate) will be executed before redux middleware handler, which means `DelayedSubscriber` will be triggered before being added. 