### PR TITLE
Fixed typing issues for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare module 'react-navigation-redux-helpers' {
     NavigationScreenProp
   } from 'react-navigation';
   import * as React from 'react';
-  import { Middleware, Reducer, Dispatch } from 'redux';
+  import { Middleware, Reducer } from 'redux';
 
   export type Navigator = NavigationContainer;
 
@@ -22,5 +22,5 @@ declare module 'react-navigation-redux-helpers' {
   export function reduxifyNavigator<S>(
     navigator: Navigator,
     key: string,
-  ): React.ComponentType<{ state: NavigationState; dispatch: Dispatch<S> }>;
+  ): React.ComponentType<{ state: NavigationState; dispatch: NavigationDispatch }>;
 }


### PR DESCRIPTION
This should be in line with the code you have in `src/reduxify-navigator.js` in which the signature of reduxiyNavigator is `reduxifyNavigator<State: NavigationState, Props: RequiredProps<State>>` and your required props are `{ state: State, dispatch: NavigationDispatch, }`