### PR TITLE
Fixes ability to use with react-navigation 3.0 for web

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module 'react-navigation-redux-helpers' {
     NavigationState,
     NavigationDispatch,
     NavigationScreenProp
-  } from 'react-navigation';
+  } from '@react-navigation/core';
   import * as React from 'react';
   import { Middleware, Reducer } from 'redux';
 

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "index.d.ts"
   ],
   "peerDependencies": {
+    "@react-navigation/core": "*",
     "react": "*",
-    "react-navigation": "*",
     "redux": "*"
   }
 }

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -8,7 +8,7 @@ import {
   type NavigationScreenProp,
   type NavigationRouter,
   getNavigation,
-} from 'react-navigation';
+} from '@react-navigation/core';
 import type { Middleware } from 'redux';
 
 import invariant from 'invariant';

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -1,10 +1,10 @@
 // @flow
 
-import type { NavigationAction, NavigationState } from 'react-navigation';
+import type { NavigationAction, NavigationState } from '@react-navigation/core';
 import type { Reducer } from 'redux';
 import type { Navigator, ReducerState } from './types'
 
-import { NavigationActions } from "react-navigation";
+import { NavigationActions } from "@react-navigation/core";
 
 const initAction = NavigationActions.init();
 

--- a/src/reduxify-navigator.js
+++ b/src/reduxify-navigator.js
@@ -5,7 +5,7 @@ import type {
   NavigationDispatch,
   NavigationContainer,
   NavigationScreenProp,
-} from 'react-navigation';
+} from '@react-navigation/core';
 
 import * as React from 'react';
 

--- a/src/types.js
+++ b/src/types.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { NavigationContainer, NavigationState } from 'react-navigation';
+import type { NavigationContainer, NavigationState } from '@react-navigation/core';
 
 export type Navigator = NavigationContainer<*, *, *>;
 export type ReducerState = ?NavigationState;


### PR DESCRIPTION
Fixes #73 by changing react-navigation peer dependency and imports 